### PR TITLE
Function InstalledPkgList modified

### DIFF
--- a/pacleaner.py
+++ b/pacleaner.py
@@ -111,7 +111,7 @@ class InstalledPkgList(PkgList):
     def __init__(self, path):
         self.path = path
         self.pkg_list = []
-        pkgs = os.listdir(path)
+        pkgs = [ p for p in os.listdir(path) if os.path.isdir(os.path.join(path, p)) ]
         for p in pkgs:
             filepath = os.path.join(path, p, "desc")
             with open(filepath) as f:
@@ -198,6 +198,7 @@ if __name__ == "__main__":
             print_packages(uninstalled)
         if args.morethan:
             print_packages(old)
+
     else:
         if args.uninstalled:
             remove_packages(uninstalled)


### PR DESCRIPTION
Since pacman 4.2 The directory /var/lib/pacman/local/ contain a file to describe the version of the database. It cause trouble in the function InstalledPkgList which try to open it as a directory. Script modified to exclude non-directory file.
