### PR TITLE
User friendly Options

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 Script to clean up pacmans cache in a more flexible way than pacman -Sc[c].
 
-usage: pacleaner.py [-h] [--uninstalled] [--morethan] [--delete] [--number n]
-                    [--cache_path PATH] [--installed_path PATH]
+usage: pacleaner.py [-h] [--uninstalled] [--morethan] [--delete] [--no-confirm]
+                    [--number n] [--cache_path PATH] [--installed_path PATH]
 
 Clean up pacman's cache. More flexible than "pacman -Sc[c]"
 
@@ -10,11 +10,20 @@ optional arguments:
   --uninstalled, -u     list packages that is not installed on the system
   --morethan, -m        list packages that has more than the specified number
                         of files in the cache
-  --delete              if this option is set, the packages listed by
-                        "uninstalled" or "morethan" is deleted.
+  --delete              if this option is set, the packages listed by 
+                        "uninstalled" or "morethan" are deleted.
+                        Confirmation could be required according the
+                        default value set for Delete_Confirmation in config file.
+  --no-confirm          if this option is set with --delete, the packages listed by 
+                        "uninstalled" or "morethan" are deleted without confirmation.
+                        No effect if the config file is stored with Delete_Confirmation = No.
   --number n, -n n      number of packages that you want to keep as a backup.
-                        Defaults to 2.
+                        Defaults to 2, this value can be changed in pacleaner_config file.
   --cache_path PATH, -c PATH
                         optional path to pacman's cache
   --installed_path PATH, -i PATH
                         optional path to pacman's installed package db
+
+A default config file "pacleaner_config" is required in the directory where the script is stored.
+A local config file can be set as "~/.config/pacleaner/pacleaner_config".
+If both are presnt, the local config file will be used first.

--- a/README
+++ b/README
@@ -24,6 +24,4 @@ optional arguments:
   --installed_path PATH, -i PATH
                         optional path to pacman's installed package db
 
-A default config file "pacleaner_config" is required in the directory where the script is stored.
-A local config file can be set as "~/.config/pacleaner/pacleaner_config".
-If both are presnt, the local config file will be used first.
+A default config file "pacleaner_config" is required in the directory /usr/share/paclaner/

--- a/pacleaner.py
+++ b/pacleaner.py
@@ -7,11 +7,11 @@ import configparser
 from operator import attrgetter
 
 config = configparser.ConfigParser()
-if os.path.isfile(os.path.join(os.path.expanduser('~'), '.config/pacleaner/pacleaner_config')):
-  config.read(os.path.join(os.path.expanduser('~'), '.config/pacleaner/pacleaner_config'))
+#if os.path.isfile(os.path.join(os.path.expanduser('~'), '.config/pacleaner/pacleaner_config')):
+#  config.read(os.path.join(os.path.expanduser('~'), '.config/pacleaner/pacleaner_config'))
 
-else:
-  config.read('pacleaner_config')
+#else:
+  config.read('/usr/share/pacleaner/pacleaner_config')
 
 PACKAGES = config['DEFAULT']['Cache_Path']
 INSTALLED = config['DEFAULT']['Installed_Path']

--- a/pacleaner_config
+++ b/pacleaner_config
@@ -1,0 +1,6 @@
+[DEFAULT]
+
+Installed_Path = /var/lib/pacman/local
+Cache_Path = /var/cache/pacman/pkg/
+Nb_Of_Pkg_Keep = 2
+Delete_Confirmation = Yes


### PR DESCRIPTION
Adding confirmation before deleting file from pacman cache directory.

Export configuration variables into a config file rather to have it directly in the script body. It allow user to fine tune the default operation of the script easily.

If variable Delete_Confirmation is set to NO and Nb_Of_Pkg_Keep is 2, the current operation of the script is unchanged
