### PR TITLE
Use of libalpm (pacman) built-in function vercmp to compare packages

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 Script to clean up pacmans cache in a more flexible way than pacman -Sc[c].
 
-usage: pacleaner.py [-h] [--uninstalled] [--morethan] [--delete] [--number n]
-                    [--cache_path PATH] [--installed_path PATH]
+usage: pacleaner.py [-h] [--uninstalled] [--morethan] [--delete] [--no-confirm]
+                    [--number n] [--cache_path PATH] [--installed_path PATH]
 
 Clean up pacman's cache. More flexible than "pacman -Sc[c]"
 
@@ -10,11 +10,20 @@ optional arguments:
   --uninstalled, -u     list packages that is not installed on the system
   --morethan, -m        list packages that has more than the specified number
                         of files in the cache
-  --delete              if this option is set, the packages listed by
-                        "uninstalled" or "morethan" is deleted.
+  --delete              if this option is set, the packages listed by 
+                        "uninstalled" or "morethan" are deleted.
+                        Confirmation could be required according the
+                        default value set for Delete_Confirmation in config file.
+  --no-confirm          if this option is set with --delete, the packages listed by 
+                        "uninstalled" or "morethan" are deleted without confirmation.
+                        No effect if the config file is stored with Delete_Confirmation = No.
   --number n, -n n      number of packages that you want to keep as a backup.
-                        Defaults to 2.
+                        Defaults to 2, this value can be changed in pacleaner_config file.
   --cache_path PATH, -c PATH
                         optional path to pacman's cache
   --installed_path PATH, -i PATH
                         optional path to pacman's installed package db
+
+A default config file "pacleaner_config" is required in the directory where the script is stored.
+A local config file can be set as "~/.config/pacleaner/pacleaner_config".
+If both are presnt, the local config file will be used first.

--- a/README
+++ b/README
@@ -24,6 +24,4 @@ optional arguments:
   --installed_path PATH, -i PATH
                         optional path to pacman's installed package db
 
-A default config file "pacleaner_config" is required in the directory where the script is stored.
-A local config file can be set as "~/.config/pacleaner/pacleaner_config".
-If both are presnt, the local config file will be used first.
+A default config file "pacleaner_config" is required in the directory /usr/share/paclaner/

--- a/pacleaner.py
+++ b/pacleaner.py
@@ -249,7 +249,7 @@ if __name__ == "__main__":
     parser.add_argument('--delete', action = 'store_true', help='if this option is set, the packages listed by "uninstalled" or "morethan" are deleted. Confirmation could be required according the default value set for ''Delete_Confirmation'' in config file')
     parser.add_argument('--no-confirm', action = 'store_true', help='if this option is set with --delete, the packages listed by "uninstalled" or "morethan" are deleted without confirmation. No effect if the config file is stored with ''Delete_Confirmation = No''')
     parser.add_argument('--number', '-n', metavar='n', type=int, default=NR_OF_PKG, help='number of packages that you want to keep as a backup. Defaults to 2, this value can be changed in pacleaner_config file.')
-    parser.add_argument('--cache_path', '-c', metavar='PATH', type=list, default=PACKAGES, help='optional path to pacman\'s cache')
+    parser.add_argument('--cache_path', '-c', metavar='PATH', type=str, nargs="+", default=PACKAGES, help='optional path to pacman\'s cache')
     parser.add_argument('--installed_path', '-i', metavar='PATH', type=str, default=INSTALLED, help='optional path to pacman\'s installed package db')
 
     args = parser.parse_args()

--- a/pacleaner.py
+++ b/pacleaner.py
@@ -25,27 +25,17 @@ class MultiOrderedDict(OrderedDict):
             super(OrderedDict, self).__setitem__(key, value)
 
 config = configparser.RawConfigParser(dict_type = MultiOrderedDict,allow_no_value=True,strict=False)
-
 config.read('/etc/pacman.conf')
+INSTALLED = os.path.join(config.get('options', 'DBPath', fallback=['/var/lib/pacman/'])[0],'local/')
+PACKAGES=[]
+for key in config.get('options', 'CacheDir', fallback = ['/var/cache/pacman/pkg/']):
+   for value in key.split():
+      PACKAGES.append(value)
 
-try:
-  INSTALLED = os.path.join(config.get('options', 'DBPath')[0],'local/')
-except KeyError:
-  INSTALLED = '/var/lib/pacman/local/'
-
-try:
-  PACKAGES=[]
-  for key in config.get('options', 'CacheDir'):
-     for value in key.split():
-        PACKAGES.append(value)
-except KeyError:
-  PACKAGES = ['/var/cache/pacman/pkg/']
-
-config = configparser.ConfigParser()   	
-config.read(os.path.join(os.path.expanduser('~'+username+'/'), '.config/pacleaner/pacleaner_config'))
-try:
-  NR_OF_PKG = int(config['DEFAULT']['Nb_Of_Pkg_Keep'])
-except KeyError:
+config = configparser.ConfigParser()
+if os.path.isfile (os.path.join(os.path.expanduser('~'+username+'/'), '.config/pacleaner/pacleaner_config')): 	
+   config.read(os.path.join(os.path.expanduser('~'+username+'/'), '.config/pacleaner/pacleaner_config'))
+else:
   config.read(os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), 'pacleaner_config'))
    
 NR_OF_PKG = int(config['DEFAULT']['Nb_Of_Pkg_Keep'])

--- a/pacleaner.py
+++ b/pacleaner.py
@@ -33,11 +33,11 @@ for key in config.get('options', 'CacheDir', fallback = ['/var/cache/pacman/pkg/
       PACKAGES.append(value)
 
 config = configparser.ConfigParser()
-if os.path.isfile (os.path.join(os.path.expanduser('~'+username+'/'), '.config/pacleaner/pacleaner_config')): 	
+if os.path.isfile (os.path.join(os.path.expanduser('~'+username+'/'), '.config/pacleaner/pacleaner_config')):
    config.read(os.path.join(os.path.expanduser('~'+username+'/'), '.config/pacleaner/pacleaner_config'))
 else:
   config.read(os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), 'pacleaner_config'))
-   
+
 NR_OF_PKG = int(config['DEFAULT']['Nb_Of_Pkg_Keep'])
 SECURE_DELETE = config.getboolean('DEFAULT' , 'Delete_Confirmation')
 EXTENSIONS = ["pkg.tar.xz", "pkg.tar.gzip"]
@@ -48,7 +48,7 @@ class Package(object):
 
     def __str__(self):
         return self.name + "-" + self.version + "-" + self.pkg_version
-    
+
     def __repr__(self):
         return repr((self.name, self.version, self.pkg_version, self.arch))
 
@@ -69,7 +69,7 @@ class Package(object):
                 return self.version < other.version
         else:
             return self.name < other.name
-                    
+
     def __le__(self, other):
         return self.__eq__(other) or self.__lt__(other)
 
@@ -115,7 +115,7 @@ class PkgList(object):
     def sort_by_ver(self):
         self.pkg_list = sorted(self.pkg_list, key = attrgetter("name"))
         for i in range(len(self.pkg_list)-2):
-           j = i+1 	   
+           j = i+1
            while self.pkg_list[j].name == self.pkg_list[i].name:
                compare_code = subprocess.check_output(['vercmp' , self.pkg_list[j].fullpath , self.pkg_list[i].fullpath])
                if int(compare_code)<0 :
@@ -123,7 +123,7 @@ class PkgList(object):
                   self.pkg_list[i] = self.pkg_list[j]
                   self.pkg_list[j] = current_pkg
                j += 1
-          
+
     def names(self):
         return [i.name for i in self.pkg_list ]
 
@@ -142,7 +142,7 @@ class PkgList(object):
         return result
 
 class PkgFileList(PkgList):
-     
+
     def __init__(self, paths):
         self.paths = paths
         self.pkg_list = []
@@ -181,7 +181,7 @@ def older_than(pkgfiles, installed, number):
         if(len(full_list) > number):
             if len(full_list[0:-number]) > 0:
                 for i in range(len(full_list)-1):
-                    j = i+1 	   
+                    j = i+1
                     while j < len(full_list):
                         compare_code = subprocess.check_output(['vercmp' , full_list[j].fullpath , full_list[i].fullpath])
                         if int(compare_code)<0 :
@@ -216,15 +216,15 @@ def print_installed(packages):
 def remove_packages(packages, confirmation):
     if (not(SECURE_DELETE) or confirmation):
       answer = "Y"
-      
+
     else:
       print_packages(packages)
       answer = input ("Are you sure you want to clean-up the pacman cache directory according the previous packages list? [y/N]")
-      
+
     if not answer.upper() == "Y":
        print("Clean-up of files in cache canceled")
        exit()
-    
+
     disk_space = 0
     for pkg in sorted (packages, key = attrgetter("name", "version", "pkg_version")):
         disk_space += pkg.pkg_size
@@ -236,7 +236,7 @@ def remove_packages(packages, confirmation):
             if e.errno == errno.EACCES:
                 print("You don't have permissions to delete this file. Run as Root?")
                 exit()
-    print ("%s of space have been free on the disk" % size(disk_space) )            
+    print ("%s of space have been free on the disk" % size(disk_space) )
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Clean up pacman\'s cache. More flexible than "pacman -Sc[c]"')
@@ -256,7 +256,7 @@ if __name__ == "__main__":
 
     if not (args.uninstalled or args.morethan):
         parser.error("Need to specify -u, -m or both")
-   
+
     installed = InstalledPkgList(args.installed_path)
     pkgfiles = PkgFileList(args.cache_path)
     old = older_than(pkgfiles, installed, args.number)

--- a/pacleaner.py
+++ b/pacleaner.py
@@ -7,11 +7,11 @@ import configparser
 from operator import attrgetter
 
 config = configparser.ConfigParser()
-if os.path.isfile(os.path.join(os.path.expanduser('~'), '.config/pacleaner/pacleaner_config')):
-  config.read(os.path.join(os.path.expanduser('~'), '.config/pacleaner/pacleaner_config'))
+#if os.path.isfile(os.path.join(os.path.expanduser('~'), '.config/pacleaner/pacleaner_config')):
+#  config.read(os.path.join(os.path.expanduser('~'), '.config/pacleaner/pacleaner_config'))
 
-else:
-  config.read('pacleaner_config')
+#else:
+  config.read('/usr/share/pacleaner/pacleaner_config')
 
 PACKAGES = config['DEFAULT']['Cache_Path']
 INSTALLED = config['DEFAULT']['Installed_Path']

--- a/pacleaner.py
+++ b/pacleaner.py
@@ -1,19 +1,25 @@
 #!/usr/bin/env python3
 
 import os
+import sys
 import errno
 import argparse
 import configparser
 from operator import attrgetter
 
 config = configparser.ConfigParser()
-#if os.path.isfile(os.path.join(os.path.expanduser('~'), '.config/pacleaner/pacleaner_config')):
-#  config.read(os.path.join(os.path.expanduser('~'), '.config/pacleaner/pacleaner_config'))
 
-#else:
-  config.read('/usr/share/pacleaner/pacleaner_config')
-
-PACKAGES = config['DEFAULT']['Cache_Path']
+username = os.getenv("SUDO_USER")
+if username is None:
+   username = os.getenv("USER")
+   	
+config.read(os.path.join(os.path.expanduser('~'+username+'/'), '.config/pacleaner/pacleaner_config'))
+try:
+  PACKAGES = config['DEFAULT']['Cache_Path']
+except KeyError:
+  config.read(os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), 'pacleaner_config'))
+  PACKAGES = config['DEFAULT']['Cache_Path']
+   
 INSTALLED = config['DEFAULT']['Installed_Path']
 NR_OF_PKG = int(config['DEFAULT']['Nb_Of_Pkg_Keep'])
 SECURE_DELETE = config.getboolean('DEFAULT' , 'Delete_Confirmation')

--- a/pacleaner_config
+++ b/pacleaner_config
@@ -1,6 +1,6 @@
 [DEFAULT]
 
 Installed_Path = /var/lib/pacman/local
-Cache_Path = /var/cache/pacman/pkg/
-Nb_Of_Pkg_Keep = 2
+Cache_Path = /var/cache/pacman/pkg
+Nb_Of_Pkg_Keep = 3
 Delete_Confirmation = Yes

--- a/pacleaner_config
+++ b/pacleaner_config
@@ -1,6 +1,4 @@
 [DEFAULT]
 
-Installed_Path = /var/lib/pacman/local
-Cache_Path = /var/cache/pacman/pkg
 Nb_Of_Pkg_Keep = 3
 Delete_Confirmation = Yes

--- a/pacleaner_config
+++ b/pacleaner_config
@@ -1,0 +1,6 @@
+[DEFAULT]
+
+Installed_Path = /var/lib/pacman/local
+Cache_Path = /var/cache/pacman/pkg/
+Nb_Of_Pkg_Keep = 2
+Delete_Confirmation = Yes


### PR DESCRIPTION
Sorted packages on name and version as string brought some error, as example

pkg-3.0-10
pkg-3.0-7
pkg-3.0-8
pkg-3.0-9

Instead of :

pkg-3.0-7
pkg-3.0-8
pkg-3.0-9
pkg-3.0-10

I have used the built-in tools "vercmp" of pacman to avoid anymore problem.

This pull request should also includ user-friendly options
